### PR TITLE
웹툰 MSA 플랫폼 API Gateway 서비스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,10 @@ subprojects {
 
     // 🔽 Spring Boot BOM 적용: 하위 모듈에서 버전 없이 선언 가능
     dependencyManagement {
-        imports { mavenBom "org.springframework.boot:spring-boot-dependencies:3.4.4" }
+        imports { 
+            mavenBom "org.springframework.boot:spring-boot-dependencies:3.4.4"
+            mavenBom "org.springframework.cloud:spring-cloud-dependencies:2024.0.2"
+        }
     }
 
     dependencies { testImplementation 'org.springframework.boot:spring-boot-starter-test' }

--- a/services/api-gateway/build.gradle
+++ b/services/api-gateway/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'org.springframework.boot'
+    id 'java'
+}
+
+dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.6.0'
+    
+    // 레이트리밋용 Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/services/api-gateway/src/main/java/com/yoordi/gw/GatewayApplication.java
+++ b/services/api-gateway/src/main/java/com/yoordi/gw/GatewayApplication.java
@@ -1,8 +1,12 @@
 package com.yoordi.gw;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class GwApplication {
-    public static void main(String[] args) { SpringApplication.run(GwApplication.class, args); }
+public class GatewayApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayApplication.class, args);
+    }
 }

--- a/services/api-gateway/src/main/java/com/yoordi/gw/api/InfoController.java
+++ b/services/api-gateway/src/main/java/com/yoordi/gw/api/InfoController.java
@@ -1,0 +1,37 @@
+package com.yoordi.gw.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@Tag(name = "Gateway Info", description = "API Gateway routing information")
+public class InfoController {
+    
+    @Operation(summary = "게이트웨이 라우트 요약", description = "현재 설정된 라우트 및 레이트 제한 정보")
+    @GetMapping("/routes-info")
+    public Map<String, Object> routesInfo() {
+        return Map.of(
+            "gateway", "msa-webtoon API Gateway",
+            "routes", Map.of(
+                "/ingest/**", "http://localhost:8101 (event-ingest service)",
+                "/rank/**", "http://localhost:8102 (rank-service)"
+            ),
+            "rateLimit", Map.of(
+                "type", "per IP address",
+                "ingest", "200 req/sec (burst: 400)",
+                "rank", "300 req/sec (burst: 600)"
+            ),
+            "features", new String[]{
+                "Request ID correlation",
+                "Response time tracking", 
+                "Access logging",
+                "Redis-based rate limiting",
+                "CORS support"
+            }
+        );
+    }
+}

--- a/services/api-gateway/src/main/java/com/yoordi/gw/filter/AccessLogFilter.java
+++ b/services/api-gateway/src/main/java/com/yoordi/gw/filter/AccessLogFilter.java
@@ -1,0 +1,42 @@
+package com.yoordi.gw.filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+public class AccessLogFilter implements GlobalFilter, Ordered {
+    
+    private static final Logger logger = LoggerFactory.getLogger(AccessLogFilter.class);
+    
+    @Override 
+    public int getOrder() { 
+        return 100; // 나중에 실행
+    }
+    
+    @Override 
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        var request = exchange.getRequest();
+        var requestId = request.getHeaders().getFirst("X-Request-Id");
+        
+        return chain.filter(exchange).doOnSuccess(result -> {
+            var response = exchange.getResponse();
+            logger.info("gw access rid={} method={} path={} status={}", 
+                       requestId, 
+                       request.getMethod(), 
+                       request.getURI().getPath(), 
+                       response.getStatusCode());
+        }).doOnError(error -> {
+            logger.error("gw access rid={} method={} path={} error={}", 
+                        requestId, 
+                        request.getMethod(), 
+                        request.getURI().getPath(), 
+                        error.getMessage());
+        });
+    }
+}

--- a/services/api-gateway/src/main/java/com/yoordi/gw/filter/RequestIdFilter.java
+++ b/services/api-gateway/src/main/java/com/yoordi/gw/filter/RequestIdFilter.java
@@ -1,0 +1,48 @@
+package com.yoordi.gw.filter;
+
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Component
+public class RequestIdFilter implements GlobalFilter, Ordered {
+    
+    public static final String HDR = "X-Request-Id";
+    
+    @Override 
+    public int getOrder() { 
+        return -100; // 먼저 실행
+    }
+    
+    @Override 
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        var request = exchange.getRequest();
+        String requestId = request.getHeaders().getFirst(HDR);
+        
+        if (requestId == null || requestId.isBlank()) {
+            requestId = UUID.randomUUID().toString();
+        }
+        
+        final String finalRequestId = requestId; // final 변수로 만들어 lambda에서 사용
+        
+        // 응답에 Request ID 추가
+        exchange.getResponse().getHeaders().add(HDR, finalRequestId);
+        
+        // 요청에 Request ID 추가하여 다운스트림 서비스로 전달
+        var mutatedRequest = exchange.mutate()
+                .request(builder -> builder.headers(headers -> headers.add(HDR, finalRequestId)))
+                .build();
+        
+        long startTime = System.nanoTime();
+        
+        return chain.filter(mutatedRequest).doFinally(signalType -> {
+            long durationMs = (System.nanoTime() - startTime) / 1_000_000;
+            exchange.getResponse().getHeaders().add("X-Response-Time-ms", String.valueOf(durationMs));
+        });
+    }
+}

--- a/services/api-gateway/src/main/java/com/yoordi/gw/ratelimit/IpKeyResolver.java
+++ b/services/api-gateway/src/main/java/com/yoordi/gw/ratelimit/IpKeyResolver.java
@@ -1,0 +1,31 @@
+package com.yoordi.gw.ratelimit;
+
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component("ipKeyResolver")
+public class IpKeyResolver implements KeyResolver {
+    
+    @Override
+    public Mono<String> resolve(ServerWebExchange exchange) {
+        var request = exchange.getRequest();
+        
+        // X-Forwarded-For 헤더에서 실제 클라이언트 IP 추출
+        String clientIp = request.getHeaders().getFirst("X-Forwarded-For");
+        
+        // X-Forwarded-For가 없으면 Remote Address 사용
+        if (clientIp == null || clientIp.isBlank()) {
+            var remoteAddress = request.getRemoteAddress();
+            clientIp = remoteAddress != null ? 
+                      remoteAddress.getAddress().getHostAddress() : 
+                      "unknown";
+        } else {
+            // X-Forwarded-For는 comma-separated list일 수 있으므로 첫 번째 IP 사용
+            clientIp = clientIp.split(",")[0].trim();
+        }
+        
+        return Mono.just(clientIp);
+    }
+}

--- a/services/api-gateway/src/main/resources/application.yml
+++ b/services/api-gateway/src/main/resources/application.yml
@@ -1,3 +1,65 @@
-server.port: 8080
-management.endpoints.web.exposure.include: health,info,prometheus
-springdoc.swagger-ui.enabled: true
+server:
+  port: 8080
+
+spring:
+  application:
+    name: api-gateway
+  main:
+    web-application-type: reactive
+  cloud:
+    gateway:
+      default-filters:
+        - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials
+        - AddResponseHeader=X-Gateway,msa-webtoon
+      routes:
+        - id: ingest
+          uri: http://localhost:8101
+          predicates: 
+            - Path=/ingest/**
+          filters:
+            - name: RequestRateLimiter
+              args:
+                key-resolver: "#{@ipKeyResolver}"
+                redis-rate-limiter.replenishRate: 200   # 초당 200
+                redis-rate-limiter.burstCapacity: 400
+        - id: rank
+          uri: http://localhost:8102
+          predicates: 
+            - Path=/rank/**
+          filters:
+            - name: RequestRateLimiter
+              args:
+                key-resolver: "#{@ipKeyResolver}"
+                redis-rate-limiter.replenishRate: 300
+                redis-rate-limiter.burstCapacity: 600
+      httpclient:
+        connect-timeout: 3000
+        response-timeout: 5s
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  webflux:
+    base-path: /
+    cors:
+      mappings:
+        "/**":
+          allowed-origins: "*"
+          allowed-methods: "*"
+          allowed-headers: "*"
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: when_authorized
+
+springdoc:
+  swagger-ui:
+    enabled: true
+


### PR DESCRIPTION
Spring Cloud Gateway 기반의 API 게이트웨이 구축으로 마이크로서비스 통합 라우팅 및 트래픽 제어 기능을 제공합니다.

주요 기능:
- 라우팅: /ingest/** → event-ingest (8101), /rank/** → rank-service (8102)
- Redis 기반 IP별 요청 제한: ingest 200req/s, rank 300req/s
- 요청 추적: X-Request-Id 헤더를 통한 분산 추적 지원
- 응답시간 측정: X-Response-Time-ms 헤더 자동 추가
- 접근 로깅: 상관관계 ID를 포함한 종합 요청 로그
- CORS 지원: 크로스 오리진 요청 허용
- 메트릭 엔드포인트: /actuator/health, /actuator/prometheus
- 라우팅 정보 API: /routes-info

기술 스택: Java 21, Spring Boot 3.4.4, Spring Cloud Gateway 2024.0.2, WebFlux

🤖 Generated with [Claude Code](https://claude.ai/code)